### PR TITLE
Add command line application for VHDL/Verilog generation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ lazy val root = (project in file(".")).
     )),
     libraryDependencies ++= Seq(
       spinalCore, spinalLib, spinalIdslPlugin,
-      "org.scalatest" %% "scalatest" % "3.2.18" % "test"
+      "org.scalatest" %% "scalatest" % "3.2.18" % "test",
+      "com.github.alexarchambault" %% "case-app" % "2.0.6"
     ),
     name := "Fpxx"
   ).dependsOn()

--- a/src/main/scala/math/Fpxx.scala
+++ b/src/main/scala/math/Fpxx.scala
@@ -30,12 +30,12 @@ object FpxxConfig {
       signed_zero = false
     )
     def float8_e4m3fnuz = FpxxConfig(
-        4,
-        3,
-        SpecialNan(BigInt("10000000", 2)),
-        inf_encoding = NoInfinity(BigInt("10000000", 2)),
-        exp_bias = CustomBias(8),
-        signed_zero = false
+      4,
+      3,
+      SpecialNan(BigInt("10000000", 2)),
+      inf_encoding = NoInfinity(BigInt("10000000", 2)),
+      exp_bias = CustomBias(8),
+      signed_zero = false
     )
 }
 
@@ -220,6 +220,8 @@ case class FpxxHost(value: BigInt, c: FpxxConfig, maxUlpDist: Int = 0, testZeroS
         (value - other.value).abs
     }
 
+    def setMaxUlpDist(newMaxUlpDist: Int) = FpxxHost(value, c, newMaxUlpDist, testZeroSign)
+
     override def toString = {
         // align to 4 bit boundary
         val mantissa_aligned    = mant << (4 - (c.mant_size % 4))
@@ -239,14 +241,15 @@ case class FpxxHost(value: BigInt, c: FpxxConfig, maxUlpDist: Int = 0, testZeroS
 
     override def equals(other: Any): Boolean = {
         other match {
-            case o @ FpxxHost(_, oc, _, _) =>
+            case o @ FpxxHost(_, oc, _, _) => {
+                val maxUlp = maxUlpDist.max(o.maxUlpDist)
                 c == oc &&
-                (ulpDist(o) <= maxUlpDist ||
+                (ulpDist(o) <= maxUlp ||
                     isNan && o.isNan ||
                     isInf && o.isInf && sign == o.sign ||
                     (!testZeroSign || !o.testZeroSign) && isZero && o.isZero)
+            }
             case _ => false
         }
     }
 }
-

--- a/src/main/scala/math/Fpxx.scala
+++ b/src/main/scala/math/Fpxx.scala
@@ -29,6 +29,14 @@ object FpxxConfig {
       exp_bias = CustomBias(16),
       signed_zero = false
     )
+    def float8_e4m3fnuz = FpxxConfig(
+        4,
+        3,
+        SpecialNan(BigInt("10000000", 2)),
+        inf_encoding = NoInfinity(BigInt("10000000", 2)),
+        exp_bias = CustomBias(8),
+        signed_zero = false
+    )
 }
 
 case class FpxxConfig(

--- a/src/main/scala/math/FpxxAccum.scala
+++ b/src/main/scala/math/FpxxAccum.scala
@@ -1,0 +1,92 @@
+package math
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.fsm._
+
+/*
+ Accumulator which works by keeping a number of sums equal to the number of pipeline stages in flight.
+ Stalls for stages * log2(stages) cycles after last accumulation element is received.
+ */
+case class FpxxAccum(o: FpxxAdd.Options) extends Component {
+    val adder = new FpxxAdd(o)
+
+    val io = new Bundle {
+        val op     = slave Stream (Fragment(Fpxx(o.c)))
+        val result = master Stream (Fpxx(o.c))
+    }
+
+    val adderLatency = LatencyAnalysis(adder.io.op.valid, adder.io.result.valid)
+    assert(adderLatency > 0, "Accumulator only supports pipelined adder")
+
+    io.result.payload.setAsReg() init
+
+    // Keep track of the number of in-flight sums in order to reduce them at the end
+    val inFlight = Reg(UInt(log2Up(adderLatency + 1) bits)) init 0
+
+    when(adder.io.op.fire && !adder.io.result.fire) {
+        assert(inFlight < adderLatency.intValue() || clockDomain.isResetActive, "inFlight should not overflow")
+        inFlight := inFlight + 1
+    } elsewhen (!adder.io.op.fire && adder.io.result.fire) {
+        assert(inFlight > 0 || clockDomain.isResetActive, "inFlight should not underflow")
+        inFlight := inFlight - 1
+    }
+
+    adder.io.op.a      := io.result.payload
+    adder.io.op.b.sign := False
+    adder.io.op.b.set_zero()
+
+    adder.io.op.valid := False
+    io.op.ready       := False
+    io.result.valid   := False
+    val fsm = new StateMachine {
+        val receive: State = new State with EntryPoint {
+            whenIsActive {
+                io.op.ready := True
+
+                // Continually recirculate the sums since we don't use backpressure in the adder
+                adder.io.op.valid := True
+
+                when(io.op.valid) {
+                    io.result.payload.set_zero()
+                    adder.io.op.b := io.op.fragment
+                    when(io.op.last) {
+                        goto(reduce)
+                    }
+                }
+
+                when(adder.io.result.valid) {
+                    io.result.payload := adder.io.result
+                }
+            }
+        }
+
+        val reduce = new State {
+            whenIsActive {
+                io.op.ready       := False
+                adder.io.op.b     := adder.io.result
+                adder.io.op.valid := False
+
+                when(adder.io.result.valid) {
+                    // Only issue more additions when the accumulator is non-zero
+                    // and there are sums in-flight
+                    when(inFlight > 0 && !io.result.payload.is_zero()) {
+                        adder.io.op.valid := True
+                        io.result.payload.set_zero()
+                    } otherwise {
+                        // Else the accumulator is empty and we can set it
+                        io.result.payload := adder.io.result
+                    }
+                }
+
+                // We are done when the are no more sums in-flight
+                io.result.valid := inFlight === 0
+
+                when(io.result.fire) {
+                    io.result.payload.set_zero()
+                    goto(receive)
+                }
+            }
+        }
+    }
+}

--- a/src/main/scala/math/FpxxRSqrt.scala
+++ b/src/main/scala/math/FpxxRSqrt.scala
@@ -1,115 +1,128 @@
-
 package math
 
 import spinal.core._
+import spinal.lib._
+import spinal.lib.misc.pipeline._
 
-case class FpxxRSqrtConfig(
-    pipeStages      : Int = 1,
-    tableSizeBits   : Int = -1,
-    lutMantBits     : Int = -1
-            ){
+object FpxxRSqrt {
+    import caseapp._
+
+    case class Options(
+        @HelpMessage(cli.Cli.fpxxConfigHelpMsg)
+        c: FpxxConfig,
+        @HelpMessage(cli.Cli.stageMaskHelpMsg(1))
+        pipeStages: StageMask = 0,
+        @HelpMessage("Log2 number of words in the lookup table. Default = no. mantissa bits")
+        tableSizeBits: Int = -1,
+        @HelpMessage("Number of mantissa bits provided by lookup table. Default = no. mantissa bits / 2")
+        lutMantBits: Int = -1
+    )
 }
 
-class FpxxRSqrt(c: FpxxConfig, rsqrtConfig: FpxxRSqrtConfig = null) extends Component {
+case class FpxxRSqrtConfig(
+    pipeStages: Int = 1,
+    tableSizeBits: Int = -1,
+    lutMantBits: Int = -1
+) {}
 
-    assert(c.ieee_like, "Can only handle IEEE compliant floats")
-    def pipeStages      = if (rsqrtConfig == null) 0 else rsqrtConfig.pipeStages
-    def lutMantBits     = if (rsqrtConfig == null || rsqrtConfig.lutMantBits < 0)   c.mant_size   else rsqrtConfig.lutMantBits
-    def tableSizeBits   = if (rsqrtConfig == null || rsqrtConfig.tableSizeBits < 0) c.mant_size/2 else rsqrtConfig.tableSizeBits
-    def tableSize       = (1<<tableSizeBits)-(1<<(tableSizeBits-2))
+case class FpxxRSqrt(o: FpxxRSqrt.Options) extends Component {
 
-    def rsqrtTableContents = for(i <- 0 until tableSize) yield {
+    assert(o.c.ieee_like, "Can only handle IEEE compliant floats")
+    def lutMantBits   = if (o.lutMantBits < 0) o.c.mant_size else o.lutMantBits
+    def tableSizeBits = if (o.tableSizeBits < 0) o.c.mant_size / 2 else o.tableSizeBits
+    def tableSize     = (1 << tableSizeBits) - (1 << (tableSizeBits - 2))
+
+    implicit val maskConfig = StageMask.Config(1, List(0))
+
+    def rsqrtTableContents = for (i <- 0 until tableSize) yield {
         // For implicit conversion between Double and FpxxHost
-        import math.FpxxHost._
+        import FpxxHost._
 
         // Values in range (0.5, 2.0(
-        val fin     = ((1L<<(tableSizeBits-2)) + i).toDouble / (1L<<(tableSizeBits-1)).toDouble;
-        val fout    = 1.0 / scala.math.sqrt(fin)
+        val fin  = ((1L << (tableSizeBits - 2)) + i).toDouble / (1L << (tableSizeBits - 1)).toDouble;
+        val fout = 1.0 / scala.math.sqrt(fin)
 
         val shift = if (fin.exp - fout.exp > 0) 1 else 0
 
-        val round = (fout.mant >> (fout.c.mant_size -lutMantBits+1)) & 1
-        val fout_mant = (fout.mant >> (fout.c.mant_size-lutMantBits)) + round
+        val round     = (fout.mant >> (fout.c.mant_size - lutMantBits + 1)) & 1
+        val fout_mant = (fout.mant >> (fout.c.mant_size - lutMantBits)) + round
 
         // printf("RSqrt table: %d: %10f -> %10f : %08x, %d, %d\n", i, fin, fout, fout_mant, (fin_exp-fout_exp), shift)
 
-        U( (fout_mant << 2) | (shift & 0x3), (lutMantBits+2) bits) 
+        U((fout_mant << 2) | (shift & 0x3), (lutMantBits + 2) bits)
     }
 
-    val rsqrt_table = Mem(UInt(lutMantBits+2 bits), initialContent = rsqrtTableContents)
+    val rsqrt_table = Mem(UInt(lutMantBits + 2 bits), initialContent = rsqrtTableContents)
 
     val io = new Bundle {
-        val op_vld      = in(Bool)
-        val op          = in(Fpxx(c))
-
-        val result_vld  = out(Bool)
-        val result      = out(Fpxx(c))
+        val op     = slave Flow (Fpxx(o.c))
+        val result = master Flow (Fpxx(o.c))
     }
 
-    val p0_vld  = io.op_vld
-    val op_p0   = io.op
+    val n0 = new Node {
+        arbitrateFrom(io.op)
 
-    //============================================================
+        val vld     = insert(io.op.valid)
+        val op      = insert(io.op)
+        val op_zero = insert(io.op.is_zero() || io.op.is_subnormal())
+        val op_nan  = insert(io.op.is_nan() || io.op.sign)
+        val op_inf  = insert(io.op.is_infinite())
 
-    val op_zero_p0 = op_p0.is_zero() || op_p0.is_subnormal()
-    val op_nan_p0  = op_p0.is_nan() || op_p0.sign
-    val op_inf_p0  = op_p0.is_infinite()
+        val exp = insert(io.op.exp.resize(o.c.exp_size + 1).asSInt - o.c.bias)
 
-    val exp_p0 = SInt(c.exp_size+1 bits)
-    exp_p0 := op_p0.exp.resize(c.exp_size+1).asSInt - c.bias
-
-    val gt_1_p0 = !(exp_p0).lsb
-
-    val rsqrt_addr_p0 = UInt(tableSizeBits bits)
-    rsqrt_addr_p0 := (((U(1,1 bits) @@ op_p0.mant) << gt_1_p0.asUInt) >> (c.mant_size+2-tableSizeBits)) - (1<<(tableSizeBits-2))
-
-    //============================================================
-    val p1_pipe_ena = pipeStages >= 0
-    val p1_vld      = OptPipeInit(p0_vld, False, p1_pipe_ena)
-    val op_zero_p1  = OptPipe(op_zero_p0,   p0_vld, p1_pipe_ena)
-    val op_nan_p1   = OptPipe(op_nan_p0,    p0_vld, p1_pipe_ena)
-    val op_inf_p1   = OptPipe(op_inf_p0,    p0_vld, p1_pipe_ena)
-    val exp_p1      = OptPipe(exp_p0,       p0_vld, p1_pipe_ena)
-
-    val rsqrt_val_p1 = rsqrt_table.readSync(rsqrt_addr_p0, p0_vld)
-    //============================================================
-
-    val rsqrt_shift_p1   = rsqrt_val_p1(0, 2 bits).asSInt
-    val rsqrt_mant_p1    = rsqrt_val_p1(2, lutMantBits bits)
-
-    val exp_adj_p1 = SInt(c.exp_size+1 bits)
-    exp_adj_p1 := -((exp_p1+1) |>> 1) - rsqrt_shift_p1 + c.bias
-
-    val sign_final_p1 = Bool
-    val exp_final_p1  = UInt(c.exp_size bits)
-    val mant_final_p1 = UInt(c.mant_size bits)
-
-    when(op_nan_p1){
-        // Negative -> NaN
-        sign_final_p1   := False
-        exp_final_p1.setAll
-        mant_final_p1   := (c.mant_size-1 -> True, default -> False)
-    }
-    .elsewhen(op_zero_p1){
-        // Infinity
-        sign_final_p1   := False
-        exp_final_p1.setAll
-        mant_final_p1.clearAll
-    }
-    .elsewhen(op_inf_p1 || exp_adj_p1 <= 0){
-        // Underflow
-        sign_final_p1   := False
-        exp_final_p1.clearAll
-        mant_final_p1.clearAll
-    }
-    .otherwise{
-        sign_final_p1   := False
-        exp_final_p1    := exp_adj_p1.asUInt.resize(c.exp_size)
-        mant_final_p1   := rsqrt_mant_p1 << (c.mant_size-lutMantBits) 
+        val gt_1 = insert(!(exp).lsb)
+        val rsqrt_addr = insert(
+          (((U(
+            1,
+            1 bits
+          ) @@ io.op.mant) << gt_1.asUInt) >> (o.c.mant_size + 2 - tableSizeBits)) - (1 << (tableSizeBits - 2))
+        )
     }
 
-    io.result_vld   := p1_vld
-    io.result.sign  := sign_final_p1
-    io.result.exp   := exp_final_p1
-    io.result.mant  := mant_final_p1
+    val n1 = new Node {
+        val rsqrt_val = if (o.pipeStages(0)) {
+            rsqrt_table.readSync(n0(n0.rsqrt_addr), n0(n0.vld))
+        } else {
+            rsqrt_table.readAsync(n0.rsqrt_addr)
+        }
+
+        val rsqrt_shift = rsqrt_val(0, 2 bits).asSInt
+        val rsqrt_mant  = rsqrt_val(2, lutMantBits bits)
+
+        val exp_adj = SInt(o.c.exp_size + 1 bits)
+        exp_adj := -((n0.exp + 1) |>> 1) - rsqrt_shift + o.c.bias
+
+        val sign_final = Bool
+        val exp_final  = UInt(o.c.exp_size bits)
+        val mant_final = UInt(o.c.mant_size bits)
+
+        when(n0.op_zero) {
+            // Infinity
+            sign_final := this(n0.op).sign
+            exp_final.setAll
+            mant_final.clearAll
+        } elsewhen (this(n0.op_nan)) {
+            // Negative -> NaN
+            sign_final := False
+            exp_final.setAll
+            mant_final := (o.c.mant_size - 1 -> True, default -> False)
+        } elsewhen (n0.op_inf || exp_adj <= 0) {
+            // Underflow
+            sign_final := False
+            exp_final.clearAll
+            mant_final.clearAll
+        } otherwise {
+            sign_final := False
+            exp_final  := exp_adj.asUInt.resize(o.c.exp_size)
+            mant_final := rsqrt_mant << (o.c.mant_size - lutMantBits)
+        }
+
+        io.result.sign := sign_final
+        io.result.exp  := exp_final
+        io.result.mant := mant_final
+
+        arbitrateTo(io.result)
+    }
+
+    Builder(o.pipeStages(Seq(n0, n1)))
 }

--- a/src/main/scala/math/Misc.scala
+++ b/src/main/scala/math/Misc.scala
@@ -134,7 +134,7 @@ object BundleDebug {
                 todo.foreach { case (dd, f) =>
                     if (dd.isNamed) {
                         val signal = f()
-                        signal.setName(dd.getName() + "__debug")
+                        signal.setWeakName(dd.getName() + "__debug")
                     }
                 }
             }

--- a/src/main/scala/math/Misc.scala
+++ b/src/main/scala/math/Misc.scala
@@ -1,4 +1,3 @@
-
 package math
 
 import spinal.core._
@@ -6,6 +5,7 @@ import spinal.core.sim._
 
 import scala.collection.mutable
 import spinal.lib.sim.Phase
+import spinal.lib.misc.pipeline.StageLink
 
 object LeadingZeros {
 
@@ -13,38 +13,39 @@ object LeadingZeros {
     // https://electronics.stackexchange.com/questions/196914/verilog-synthesize-high-speed-leading-zero-count
     // Code by @typingArtist on SpinalHDL gitter channel: https://gitter.im/SpinalHDL/SpinalHDL?at=5bbe075e435c2a518e81dd83
 
-    def apply(input: Bits): UInt = calcOnes(~input).resize(log2Up(input.getWidth+1))
+    def apply(input: Bits): UInt = calcOnes(~input).resize(log2Up(input.getWidth + 1))
 
     def calcOnes(input: Bits): UInt = input.getWidth match {
         case 0 => U""
         case 1 => input.asUInt
         case a => {
-            val leftBits = 1 << (log2Up(a)-1)
-            val upper = calcOnes(input.resizeLeft(leftBits))
-            val lower = calcOnes(input.resize(a - leftBits)).resize(upper.getWidth)
+            val leftBits = 1 << (log2Up(a) - 1)
+            val upper    = calcOnes(input.resizeLeft(leftBits))
+            val lower    = calcOnes(input.resize(a - leftBits)).resize(upper.getWidth)
             (upper.msb ## lower.msb).mux(
-                B"11"   -> U"10" @@ upper.resize(upper.getWidth-1),
-                B"10"   -> U"01" @@ lower.resize(lower.getWidth-1),
-                default -> U"00" @@ upper.resize(upper.getWidth-1)
-                )
+              B"11"   -> U"10" @@ upper.resize(upper.getWidth - 1),
+              B"10"   -> U"01" @@ lower.resize(lower.getWidth - 1),
+              default -> U"00" @@ upper.resize(upper.getWidth - 1)
+            )
         }
     }
 
 }
 
 object OptPipe {
-    def apply[T <: Data](that : T, ena: Bool, pipeline : Boolean) : T = if (pipeline) RegNextWhen(that, ena) else that
-    def apply[T <: Data](that : T, pipeline : Boolean) : T = apply(that, True, pipeline)
+    def apply[T <: Data](that: T, ena: Bool, pipeline: Boolean): T = if (pipeline) RegNextWhen(that, ena) else that
+    def apply[T <: Data](that: T, pipeline: Boolean): T            = apply(that, True, pipeline)
 }
 
 object OptPipeInit {
-    def apply[T <: Data](that : T, init: T, ena: Bool, pipeline : Boolean) : T = if (pipeline) RegNextWhen(that, ena) init(init) else that
-    def apply[T <: Data](that : T, init: T, pipeline : Boolean) : T = apply(that, init, True, pipeline)
+    def apply[T <: Data](that: T, init: T, ena: Bool, pipeline: Boolean): T =
+        if (pipeline) RegNextWhen(that, ena) init (init) else that
+    def apply[T <: Data](that: T, init: T, pipeline: Boolean): T = apply(that, init, True, pipeline)
 }
 
 case class ScoreboardInOrder[T]() {
-    val dut = mutable.Queue[T]()
-    val ref = mutable.Queue[(T, Any)]()
+    val dut     = mutable.Queue[T]()
+    val ref     = mutable.Queue[(T, Any)]()
     var matches = 0
 
     if (Phase.isUsed) {
@@ -67,7 +68,7 @@ case class ScoreboardInOrder[T]() {
 
     def check(): Unit = {
         if (ref.nonEmpty && dut.nonEmpty) {
-            val dutHead = dut.dequeue()
+            val dutHead           = dut.dequeue()
             val (refHead, inputs) = ref.dequeue()
             if (!compare(refHead, dutHead)) {
                 println("Transaction mismatch :")
@@ -126,7 +127,7 @@ object BundleDebug {
 
                 ds match {
                     case d: Data => recurse(d)
-                    case _ => {}
+                    case _       => {}
                 }
             }
             c.rework {
@@ -149,4 +150,53 @@ object BundleDebug {
           case _          => None
       }
     )
+}
+
+object StageMask {
+    /*
+     Size determines the number of stages and enableOrder contains the order at which each stage
+     will be enabled if an int is used to initialize the mask.
+
+     A config should be made an implicit parameter whenever a mask is used.
+     */
+    case class Config(size: Int, enableOrder: List[Int]) {
+        assert(enableOrder.length == size)
+        assert(enableOrder.distinct.length == size)
+        assert(enableOrder.forall(_ < size))
+    }
+
+    /* Converts an integer to a mask by looking at the enable order given */
+    implicit def int2StageMask(x: Int) = StageMask(Right(x))
+
+    implicit def list2StageMask(x: List[Boolean]) = StageMask(Left(x))
+}
+
+/* Indicates which stages should be active */
+case class StageMask(x: Either[List[Boolean], Int]) {
+    import spinal.lib.misc.pipeline.{Node, StageLink, DirectLink, Link}
+
+    def apply(i: Int)(implicit config: StageMask.Config) = mask()(config)(i)
+
+    def mask()(implicit config: StageMask.Config): List[Boolean] = x match {
+        case Right(x) => {
+            assert(x >= 0 && x <= config.size, f"x out of range for available pipeline stages ${config.size}")
+            List.tabulate(config.size)(i => config.enableOrder.slice(0, x).contains(i))
+        }
+        case Left(x) => {
+            assert(x.length == config.size)
+            x
+        }
+    }
+
+    def apply(nodes: Seq[Node])(implicit config: StageMask.Config): Seq[Link] = {
+        assert(nodes.length - 1 == mask.length)
+        nodes
+            .sliding(2)
+            .zip(mask.iterator)
+            .map { case (pair: Seq[Node], m: Boolean) =>
+                if (m) StageLink(pair(0), pair(1)) else DirectLink(pair(0), pair(1))
+            }
+            .toSeq
+    }
+
 }

--- a/src/main/scala/math/cli/App.scala
+++ b/src/main/scala/math/cli/App.scala
@@ -1,0 +1,91 @@
+package math.cli
+
+import spinal.core._
+
+import math._
+
+object Cli {
+    import caseapp._
+    import caseapp.core.argparser.{ArgParser, SimpleArgParser}
+
+    sealed trait Command;
+
+    val fpxxConfigHelpMsg =
+        "Floating point format. May be one of (float64, float32, float16, bfloat16, e5m2fnuz, e4m2fnuz, eXmX), where X is a whole number and stands for the exponent and mantissa sizes."
+    implicit val fpxxConfigParser: ArgParser[FpxxConfig] =
+        SimpleArgParser.from[FpxxConfig]("fpxxconfig") { s =>
+            val pattern = "e(\\d+)m(\\d+)".r
+            s match {
+                case "float64"  => Right(FpxxConfig.float64)
+                case "float32"  => Right(FpxxConfig.float32)
+                case "float16"  => Right(FpxxConfig.float16)
+                case "bfloat16" => Right(FpxxConfig.bfloat16)
+                case "e5m2fnuz" => Right(FpxxConfig.float8_e5m2fnuz)
+                case "e4m3fnuz" => Right(FpxxConfig.float8_e4m3fnuz)
+                case pattern(e, m) => {
+                    val config = FpxxConfig(
+                      e.toInt,
+                      m.toInt
+                    )
+                    Right(config)
+                }
+                case other => {
+                    Left(caseapp.core.Error.Other(s"Unknown format: $other"))
+                }
+            }
+
+        }
+
+    val roundTypeHelpMsg = "Round result to: (infinity, zero, even)"
+    implicit val roundTypeParser: ArgParser[spinal.core.RoundType] =
+        SimpleArgParser.from("roundtype") {
+            case "infinity" => Right(RoundType.ROUNDTOINF)
+            case "zero"     => Right(RoundType.ROUNDTOZERO)
+            case "even"     => Right(RoundType.ROUNDTOEVEN)
+            case other      => Left(caseapp.core.Error.Other(s"Unknown rounding type: $other"))
+        }
+
+    implicit val modeParser: ArgParser[SpinalMode] = SimpleArgParser.from("mode") {
+        case "vhdl"          => Right(VHDL)
+        case "verilog"       => Right(Verilog)
+        case "systemverilog" => Right(SystemVerilog)
+        case other           => Left(caseapp.core.Error.Other(s"Unknown language: $other"))
+    }
+
+    def stageMaskHelpMsg(n: Int) =
+        f"How many pipeline stages to use (${n} max). Can be an integer or a mask of the form: " +
+            f"m${List.tabulate(n)(_ => 0).mkString}. 0 = disable, 1 = enable. Leftmost digit is the earliest stage."
+    implicit val stageMaskParser: ArgParser[StageMask] = SimpleArgParser.from("stageMask") { s =>
+        val mask = "m([0-1]+)".r
+        val int  = "(\\d+)".r
+        s match {
+            case mask(m) => Right(m.toCharArray.map(_.asDigit.toBoolean).toList)
+            case int(i)  => Right(i.toInt)
+            case other   => Left(caseapp.core.Error.Other(s"Unknown stage mask format: $other"))
+        }
+    }
+
+    case class FpxxAdd(@Recurse c: CommonOptions, @Recurse o: math.FpxxAdd.Options) extends Command {};
+
+    case class FpxxConverter(@Recurse c: CommonOptions, @Recurse o: math.FpxxConverter.Options) extends Command {};
+
+    case class CommonOptions(
+        @HelpMessage("Language to generate (vhdl, verilog, systemverilog)")
+        language: SpinalMode = Verilog
+    ) {}
+
+    object App extends CommandApp[Command] {
+
+        def toConfig(options: CommonOptions) = SpinalConfig(mode = options.language)
+
+        def run(command: Command, arg: RemainingArgs): Unit = {
+            command match {
+                case FpxxAdd(c, o)       => toConfig(c).generate(new math.FpxxAdd(o))
+                case FpxxConverter(c, o) => toConfig(c).generate(math.FpxxConverter(o))
+            }
+        }
+    }
+
+    // The main from App doesn't seem to work so redefine it here
+    def main(args: Array[String]): Unit = App.main(args)
+}

--- a/src/main/scala/math/cli/App.scala
+++ b/src/main/scala/math/cli/App.scala
@@ -80,7 +80,7 @@ object Cli {
 
     object App extends CommandApp[Command] {
 
-        def toConfig(options: CommonOptions) = SpinalConfig(mode = options.language)
+        def toConfig(options: CommonOptions) = SpinalConfig(mode = options.language, fixToWithWrap = false)
 
         def run(command: Command, arg: RemainingArgs): Unit = {
             command match {

--- a/src/main/scala/math/cli/App.scala
+++ b/src/main/scala/math/cli/App.scala
@@ -73,6 +73,8 @@ object Cli {
 
     case class FpxxAccum(@Recurse c: CommonOptions, @Recurse o: math.FpxxAdd.Options) extends Command {};
 
+    case class FpxxRSqrt(@Recurse c: CommonOptions, @Recurse o: math.FpxxRSqrt.Options) extends Command {};
+
     case class CommonOptions(
         @HelpMessage("Language to generate (vhdl, verilog, systemverilog)")
         language: SpinalMode = Verilog
@@ -88,6 +90,7 @@ object Cli {
                 case FpxxConverter(c, o) => toConfig(c).generate(math.FpxxConverter(o))
                 case FpxxMul(c, o)       => toConfig(c).generate(math.FpxxMul(o))
                 case FpxxAccum(c, o)     => toConfig(c).generate(math.FpxxAccum(o))
+                case FpxxRSqrt(c, o)     => toConfig(c).generate(math.FpxxRSqrt(o))
             }
         }
     }

--- a/src/main/scala/math/cli/App.scala
+++ b/src/main/scala/math/cli/App.scala
@@ -69,6 +69,8 @@ object Cli {
 
     case class FpxxConverter(@Recurse c: CommonOptions, @Recurse o: math.FpxxConverter.Options) extends Command {};
 
+    case class FpxxMul(@Recurse c: CommonOptions, @Recurse o: math.FpxxMul.Options) extends Command {};
+
     case class CommonOptions(
         @HelpMessage("Language to generate (vhdl, verilog, systemverilog)")
         language: SpinalMode = Verilog
@@ -82,6 +84,7 @@ object Cli {
             command match {
                 case FpxxAdd(c, o)       => toConfig(c).generate(new math.FpxxAdd(o))
                 case FpxxConverter(c, o) => toConfig(c).generate(math.FpxxConverter(o))
+                case FpxxMul(c, o)       => toConfig(c).generate(math.FpxxMul(o))
             }
         }
     }

--- a/src/main/scala/math/cli/App.scala
+++ b/src/main/scala/math/cli/App.scala
@@ -71,6 +71,8 @@ object Cli {
 
     case class FpxxMul(@Recurse c: CommonOptions, @Recurse o: math.FpxxMul.Options) extends Command {};
 
+    case class FpxxAccum(@Recurse c: CommonOptions, @Recurse o: math.FpxxAdd.Options) extends Command {};
+
     case class CommonOptions(
         @HelpMessage("Language to generate (vhdl, verilog, systemverilog)")
         language: SpinalMode = Verilog
@@ -85,6 +87,7 @@ object Cli {
                 case FpxxAdd(c, o)       => toConfig(c).generate(new math.FpxxAdd(o))
                 case FpxxConverter(c, o) => toConfig(c).generate(math.FpxxConverter(o))
                 case FpxxMul(c, o)       => toConfig(c).generate(math.FpxxMul(o))
+                case FpxxAccum(c, o)     => toConfig(c).generate(math.FpxxAccum(o))
             }
         }
     }

--- a/src/test/scala/math/FpxxAccumTester.scala
+++ b/src/test/scala/math/FpxxAccumTester.scala
@@ -1,0 +1,56 @@
+package math
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import spinal.sim._
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+import spinal.lib.sim.StreamDriver
+import spinal.lib.sim.StreamMonitor
+import spinal.lib.sim.StreamReadyRandomizer
+
+class FpxxAccumTester extends AnyFunSuite {
+    test("order") {
+        SimConfig.withWave
+            .compile(BundleDebug.fpxxDebugBits(FpxxAccum(FpxxAdd.Options(FpxxConfig.float32(), 1))))
+            .doSim { dut =>
+                SimTimeout(1000000)
+                dut.clockDomain.forkStimulus(2)
+
+                dut.clockDomain.waitActiveEdge(2)
+
+                val scoreboard = ScoreboardInOrder[FpxxHost]
+
+                val samples = (1 to 30).map { i =>
+                    val nums     = (1 to i).map(_.toFloat).toList
+                    val sum      = nums.sum
+                    val boolList = List.fill(nums.length - 1)(false) :+ true
+                    scoreboard.pushRef(FpxxHost(sum), nums)
+                    (nums.zip(boolList).toList, sum)
+                }.toList
+
+                val (driver, queue) = StreamDriver.queue(dut.io.op, dut.clockDomain)
+                driver.setFactor(0.95f)
+                queue ++= samples
+                    .map(_._1)
+                    .flatten
+                    .map(x =>
+                        (payload: Fragment[Fpxx]) => {
+                            payload.fragment #= FpxxHost(x._1)
+                            payload.last #= x._2
+                        }
+                    )
+                    .toList
+
+                StreamMonitor(dut.io.result, dut.clockDomain) { payload =>
+                    scoreboard.pushDut(payload.toHost())
+                }
+
+                StreamReadyRandomizer(dut.io.result, dut.clockDomain).setFactor(0.95f)
+
+                dut.clockDomain.waitActiveEdgeWhere(queue.isEmpty && scoreboard.ref.isEmpty)
+            }
+    }
+
+}

--- a/src/test/scala/math/FpxxAddTester.scala
+++ b/src/test/scala/math/FpxxAddTester.scala
@@ -16,7 +16,7 @@ object FpxxAddTester {
         val op     = slave Flow (Vec(Fpxx(config), 2))
         val result = master Flow (Fpxx(config))
 
-        val inner = new FpxxAdd(config)
+        val inner = new FpxxAdd(FpxxAdd.Options(config))
         inner.io.op.valid := op.valid
         inner.io.op.a     := op.payload(0)
         inner.io.op.b     := op.payload(1)

--- a/src/test/scala/math/FpxxConverterTester.scala
+++ b/src/test/scala/math/FpxxConverterTester.scala
@@ -16,7 +16,7 @@ class FpxxConverterTester extends AnyFunSuite {
         testLines: Iterator[String]
     ) {
         SimConfig.withWave.noOptimisation
-            .compile(FpxxConverter(inConfig, outConfig, pipeStages = (true, true, true, true)))
+            .compile(FpxxConverter(FpxxConverter.Options(inConfig, outConfig, pipeStages = List(true, true, true, true))))
             .doSim { dut =>
                 SimTimeout(1000000)
                 val stimuli = FpxxTesterSupport.parseHexCases(testLines, 1, inConfig, outConfig)

--- a/src/test/scala/math/FpxxMulTester.scala
+++ b/src/test/scala/math/FpxxMulTester.scala
@@ -13,7 +13,7 @@ import spinal.lib.sim.FlowMonitor
 
 object FpxxMulTester extends AnyFunSuite {
     case class FpxxMulDut(config: FpxxConfig) extends Component {
-        val dut = FpxxMul(config, mulConfig = FpxxMulConfig(pipeStages = 2))
+        val dut = FpxxMul(FpxxMul.Options(cIn = config, pipeStages = 2))
 
         val op = slave(Flow(Vec(cloneOf(dut.io.input.payload.a), 2)))
         dut.io.input << op.map { payload =>
@@ -80,9 +80,7 @@ class FpxxMulTester extends AnyFunSuite {
                 bConv.io.a.valid   := True
 
                 val mult = FpxxMul(
-                  FpxxConfig(8, 2),
-                  Some(outConfig),
-                  mulConfig = FpxxMulConfig(pipeStages = 2, rounding = RoundType.FLOOR)
+                  FpxxMul.Options(FpxxConfig(8, 2), Some(outConfig), pipeStages = 2, rounding = RoundType.FLOOR)
                 )
                 mult.io.input.payload.a := aConv.io.r
                 mult.io.input.payload.b := bConv.io.r

--- a/src/test/scala/math/FpxxMulTester.scala
+++ b/src/test/scala/math/FpxxMulTester.scala
@@ -72,8 +72,8 @@ class FpxxMulTester extends AnyFunSuite {
                 val input  = slave Flow (Vec(Fpxx(inConfig), 2))
                 val result = master Flow (Fpxx(outConfig))
 
-                val aConv = FpxxConverter(inConfig, FpxxConfig(8, 2))
-                val bConv = FpxxConverter(inConfig, FpxxConfig(8, 2))
+                val aConv = FpxxConverter(FpxxConverter.Options(inConfig, FpxxConfig(8, 2)))
+                val bConv = FpxxConverter(FpxxConverter.Options(inConfig, FpxxConfig(8, 2)))
                 aConv.io.a.payload := input.payload(0)
                 aConv.io.a.valid   := True
                 bConv.io.a.payload := input.payload(1)

--- a/src/test/scala/math/FpxxRSqrtTester.scala
+++ b/src/test/scala/math/FpxxRSqrtTester.scala
@@ -1,4 +1,3 @@
-
 package math
 
 import org.scalatest.funsuite.AnyFunSuite
@@ -9,129 +8,24 @@ import spinal.sim._
 import spinal.core._
 import spinal.core.sim._
 
-object FpxxRSqrtTester {
-
-    class FpxxRSqrtDut(config: FpxxConfig) extends Component {
-        val io = new Bundle {
-            val op_vld      = in(Bool)
-            val op          = in(Bits(config.full_size bits))
-
-            val result_vld  = out(Bool)
-            val result      = out(Bits(config.full_size bits))
-        }
-
-        val fp_op = new FpxxRSqrt(config, FpxxRSqrtConfig(pipeStages = 5) )
-        fp_op.io.op_vld :=    RegNext(io.op_vld) init(False)
-        fp_op.io.op.assignFromBits(RegNext(io.op))
-
-        io.result_vld := RegNext(fp_op.io.result_vld) init(False)
-        io.result     := RegNext(fp_op.io.result).asBits
-    }
-}
-
 class FpxxRSqrtTester extends AnyFunSuite {
+    test("32 bit") {
+        val config = FpxxConfig.float32()
 
-    def resultMatches(op: Float, expected: Float, actual: Float, verbose: Boolean = false) : Boolean = {
+        SimConfig.withIVerilog.withWave.noOptimisation
+            .compile(BundleDebug.fpxxDebugBits(FpxxRSqrt(FpxxRSqrt.Options(config, pipeStages = 1))))
+            .doSim { dut =>
+                val lines = testfloatGen(Seq("-n", "100000", "f32")).map(s => {
+                    val input   = java.lang.Float.intBitsToFloat(Integer.parseUnsignedInt(s, 16))
+                    val invsqrt = 1.0 / scala.math.sqrt(input)
+                    f"$s ${FpxxHost(invsqrt.floatValue()).value}%x"
+                })
 
-        val actualMant   : Long = Fp32.mant(actual)
-        val expectedMant : Long = Fp32.mant(expected)
-
-        val mantDiff = (actualMant - expectedMant).abs
-
-        var matches = false
-        matches |= Fp32.isDenormal(expected) && Fp32.isZero(actual)
-        matches |= Fp32.isInfinite(expected) && Fp32.isInfinite(actual)
-        matches |= Fp32.isNaN(expected)      && Fp32.isNaN(actual)
-        matches |= (Fp32.exp(expected)  == Fp32.exp(actual))  &&
-                   (Fp32.sign(expected) == Fp32.sign(actual)) &&
-                   (mantDiff < (1<<(24/2+2)))
-
-        if (!matches){
-            printf("\n")
-            printf("ERROR!\n")
-            printAll(op, expected, actual)
-            printf("Mant diff: %d\n", mantDiff)
-
-            false
-        }
-        else{
-            if (verbose){
-                printf("Match!\n")
-                printAll(op, expected, actual);
+                SimTimeout(1000000)
+                val stimuli = parseHexCases(lines, 1, config, config, false, maxUlpDist = 1 << (24 / 2 + 2))
+                    // No denormals
+                    .filter { a => !a._2.isDenormal && !a._1.map(_.isDenormal).reduce(_ || _) }
+                testOperation(stimuli, dut.io.op, dut.io.result, dut.clockDomain)
             }
-            true
-        }
     }
-
-    test("FpxxRSqrt") {
-
-        val config = FpxxConfig(8, 23)
-
-        var compiled = SimConfig
-            .withWave
-            .compile(new FpxxRSqrtTester.FpxxRSqrtDut(config))
-
-        compiled.doSim { dut =>
-
-            dut.clockDomain.forkStimulus(period = 10)
-            dut.clockDomain.forkSimSpeedPrinter(0.2)
-            dut.io.op_vld #= false
-            dut.clockDomain.waitSampling()
-
-            val stimuli = Array[Float](0.0f, 0.5f, 1.0f, 1.999f, 2.0f, 100f, -1.0f, Float.NaN, Float.PositiveInfinity, Float.NegativeInfinity, Float.MaxValue )
-
-            var rand = new scala.util.Random(0)
-            var i = 0
-            var pass = 0
-            var fail = 0
-
-            while(i < stimuli.size || i < 1000000) {
-                var input = 0.0f
-                if (i < stimuli.size){
-                    input = stimuli(i)
-                }
-                else{
-                    input = Fp32.randomRegular(rand)
-                }
-
-                val op          = input
-                val result_exp  = (1.0 / scala.math.sqrt(op)).toFloat
-
-                // Convert signed int to positive long
-                var op_long : Long = Fp32.asBits(op)
-
-                // Apply operands
-                dut.io.op_vld #= true
-                dut.io.op     #= op_long
-                dut.clockDomain.waitSampling(1)
-                dut.io.op_vld #= false
-
-                // Wait until result appears
-                while(!dut.io.result_vld.toBoolean){
-                    dut.clockDomain.waitSampling()
-                }
-
-                // Actual result
-                val result_act = Fp32.asFloat(dut.io.result.toLong.toInt)
-
-                dut.clockDomain.waitSampling()
-
-                if (resultMatches(op, result_exp, result_act, verbose = false)){
-                    pass += 1
-                }
-                else {
-                    fail += 1
-                    printf("%6d: %10e\n", i, op)
-                    printf("Expected: %10e, Actual: %10e\n", result_exp, result_act);
-                    printf("--------\n")
-                    simFailure("ABORTING!")
-                }
-
-                if (i%1000 == 0) printf(".")
-                i+=1
-            }
-
-        }
-    }
-
 }

--- a/src/test/scala/math/FpxxTesterSupport.scala
+++ b/src/test/scala/math/FpxxTesterSupport.scala
@@ -150,10 +150,12 @@ object FpxxTesterSupport {
         inputN: Int,
         inConf: FpxxConfig,
         outConf: FpxxConfig,
-        testZeroSign: Boolean = true): Iterator[(List[FpxxHost], FpxxHost)] = {
+        testZeroSign: Boolean = true,
+        maxUlpDist: Int = 0
+    ): Iterator[(List[FpxxHost], FpxxHost)] = {
         lines.map{l =>
             val parts = l.split(" ").map(BigInt(_, 16)).toList
-            (parts.slice(0, inputN).map(FpxxHost(_, inConf, testZeroSign=testZeroSign)).toList, FpxxHost(parts(inputN), outConf, testZeroSign=testZeroSign))
+            (parts.slice(0, inputN).map(FpxxHost(_, inConf, testZeroSign=testZeroSign, maxUlpDist = maxUlpDist)).toList, FpxxHost(parts(inputN), outConf, testZeroSign=testZeroSign, maxUlpDist = maxUlpDist))
         }
     }
 


### PR DESCRIPTION
This introduces a command line app which can be used to generate RTL sources for the different components in the library. Right now it is only implemented for the multiplier, adder and converter. But it will be easy to add to the others.

The implementation uses case-app, and so introduces almost no overhead per-component. Only a help message per field is required. The arguments to each component also need to be placed into a separate case class, since this case class has to be created by case-app at a time when a SpinalHDL elaboration context is not available.

In order to be more flexible with how pipeline stages are activated, I added `StageMask` and `StageMaskConfig` to allow both API and CLI users to specify which stages to enable with either a number and a mask. It also makes it easier to specify in which order pipeline stages should be activated by default.